### PR TITLE
DST Root CA X3 Expired on Sept202021

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,6 @@ MAINTAINER Thomas Strohmeier
 
 RUN apt-get update \
 	&& apt-get install -y jq \
+	&& apt-get install ca-certificates \	
 	&& apt-get clean \
 	&& pip install awscli \


### PR DESCRIPTION
Need to install ca certificates as LetsEncrypt retired on of their root certs.  
Container needs to be updated with the new ca-certificates package.

@tstrohmeier - please review and do the needful if it makes sense